### PR TITLE
Feature property morphable validation

### DIFF
--- a/src/Attributes/PropertyForMorph.php
+++ b/src/Attributes/PropertyForMorph.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\LaravelData\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class PropertyForMorph
+{
+}

--- a/src/Resolvers/DataFromSomethingResolver.php
+++ b/src/Resolvers/DataFromSomethingResolver.php
@@ -3,7 +3,6 @@
 namespace Spatie\LaravelData\Resolvers;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Arr;
 use Spatie\LaravelData\Contracts\BaseData;
 use Spatie\LaravelData\Contracts\PropertyMorphableData;
 use Spatie\LaravelData\Enums\CustomCreationMethodType;
@@ -128,15 +127,12 @@ class DataFromSomethingResolver
         $dataClass = $this->dataConfig->getDataClass($class);
 
         if ($dataClass->isAbstract && $dataClass->propertyMorphable) {
-            $morphableProperties = Arr::only($properties, $dataClass->propertyMorphablePropertyNames);
+            $morphableProperties = $dataClass->propertiesForMorph($properties);
 
             /**
              * @var class-string<PropertyMorphableData> $class
              */
-            if (
-                count($morphableProperties) === count($dataClass->propertyMorphablePropertyNames)
-                && $morph = $class::morph($morphableProperties)
-            ) {
+            if ($morphableProperties && $morph = $class::morph($morphableProperties)) {
                 return $this->execute($morph, $creationContext, ...$payloads);
             }
         }

--- a/src/Resolvers/DataFromSomethingResolver.php
+++ b/src/Resolvers/DataFromSomethingResolver.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelData\Resolvers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Spatie\LaravelData\Contracts\BaseData;
 use Spatie\LaravelData\Contracts\PropertyMorphableData;
 use Spatie\LaravelData\Enums\CustomCreationMethodType;
@@ -130,7 +131,7 @@ class DataFromSomethingResolver
             /**
              * @var class-string<PropertyMorphableData> $class
              */
-            if ($morph = $class::morph($properties)) {
+            if ($morph = $class::morph(Arr::only($properties, $dataClass->propertyMorphablePropertyNames))) {
                 return $this->execute($morph, $creationContext, ...$payloads);
             }
         }

--- a/src/Resolvers/DataFromSomethingResolver.php
+++ b/src/Resolvers/DataFromSomethingResolver.php
@@ -128,10 +128,15 @@ class DataFromSomethingResolver
         $dataClass = $this->dataConfig->getDataClass($class);
 
         if ($dataClass->isAbstract && $dataClass->propertyMorphable) {
+            $morphableProperties = Arr::only($properties, $dataClass->propertyMorphablePropertyNames);
+
             /**
              * @var class-string<PropertyMorphableData> $class
              */
-            if ($morph = $class::morph(Arr::only($properties, $dataClass->propertyMorphablePropertyNames))) {
+            if (
+                count($morphableProperties) === count($dataClass->propertyMorphablePropertyNames)
+                && $morph = $class::morph($morphableProperties)
+            ) {
                 return $this->execute($morph, $creationContext, ...$payloads);
             }
         }

--- a/src/Resolvers/DataValidationRulesResolver.php
+++ b/src/Resolvers/DataValidationRulesResolver.php
@@ -119,10 +119,8 @@ class DataValidationRulesResolver
         }
 
         // Restrict to only morphable properties
-        $properties = Arr::only($properties, $dataClass->propertyMorphablePropertyNames);
-
-        // Only morph if all properties are present
-        if (count($properties) !== count($dataClass->propertyMorphablePropertyNames)) {
+        $properties = $dataClass->propertiesForMorph($properties);
+        if ($properties === null) {
             return null;
         }
 

--- a/src/Resolvers/DataValidationRulesResolver.php
+++ b/src/Resolvers/DataValidationRulesResolver.php
@@ -14,6 +14,7 @@ use Spatie\LaravelData\Support\DataConfig;
 use Spatie\LaravelData\Support\DataProperty;
 use Spatie\LaravelData\Support\Validation\DataRules;
 use Spatie\LaravelData\Support\Validation\PropertyRules;
+use Spatie\LaravelData\Support\Validation\RequiresPropertyMorphableClassRule;
 use Spatie\LaravelData\Support\Validation\RuleDenormalizer;
 use Spatie\LaravelData\Support\Validation\RuleNormalizer;
 use Spatie\LaravelData\Support\Validation\ValidationContext;
@@ -76,6 +77,10 @@ class DataValidationRulesResolver
                 $fullPayload,
                 $path,
             );
+
+            if ($dataProperty->isForMorph) {
+                $rules[] = new RequiresPropertyMorphableClassRule($dataClass);
+            }
 
             $dataRules->add($propertyPath, $rules);
         }

--- a/src/Support/DataClass.php
+++ b/src/Support/DataClass.php
@@ -35,7 +35,8 @@ class DataClass
         public DataStructureProperty $allowedRequestOnly,
         public DataStructureProperty $allowedRequestExcept,
         public DataStructureProperty $outputMappedProperties,
-        public DataStructureProperty $transformationFields
+        public DataStructureProperty $transformationFields,
+        public readonly array $propertyMorphablePropertyNames
     ) {
     }
 

--- a/src/Support/DataClass.php
+++ b/src/Support/DataClass.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelData\Support;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
 /**
@@ -35,8 +36,7 @@ class DataClass
         public DataStructureProperty $allowedRequestOnly,
         public DataStructureProperty $allowedRequestExcept,
         public DataStructureProperty $outputMappedProperties,
-        public DataStructureProperty $transformationFields,
-        public readonly array $propertyMorphablePropertyNames
+        public DataStructureProperty $transformationFields
     ) {
     }
 
@@ -58,5 +58,18 @@ class DataClass
                 $this->$propertyName = $property->toDataStructureProperty();
             }
         }
+    }
+
+    public function propertiesForMorph(array $properties): ?array
+    {
+        $requiredProperties = $this->properties->filter(fn (DataProperty $property) => $property->isForMorph)->pluck('name');
+        $forMorph = Arr::only($properties, $requiredProperties->all());
+
+        // If all required properties are not present, return null
+        if (count($forMorph) !== $requiredProperties->count()) {
+            return null;
+        }
+
+        return $forMorph;
     }
 }

--- a/src/Support/DataProperty.php
+++ b/src/Support/DataProperty.php
@@ -29,6 +29,7 @@ class DataProperty
         public readonly ?string $inputMappedName,
         public readonly ?string $outputMappedName,
         public readonly Collection $attributes,
+        public readonly bool $isForMorph,
     ) {
     }
 }

--- a/src/Support/Factories/DataClassFactory.php
+++ b/src/Support/Factories/DataClassFactory.php
@@ -104,6 +104,10 @@ class DataClassFactory
             allowedRequestExcept: new LazyDataStructureProperty(fn (): ?array => $responsable ? $name::allowedRequestExcept() : null),
             outputMappedProperties: $outputMappedProperties,
             transformationFields: static::resolveTransformationFields($properties),
+            propertyMorphablePropertyNames: $properties->filter(fn (DataProperty $property) => $property->isForMorph)
+                ->map(fn (DataProperty $property) => $property->name)
+                ->values()
+                ->all(),
         );
     }
 

--- a/src/Support/Factories/DataClassFactory.php
+++ b/src/Support/Factories/DataClassFactory.php
@@ -103,11 +103,7 @@ class DataClassFactory
             allowedRequestOnly: new LazyDataStructureProperty(fn (): ?array => $responsable ? $name::allowedRequestOnly() : null),
             allowedRequestExcept: new LazyDataStructureProperty(fn (): ?array => $responsable ? $name::allowedRequestExcept() : null),
             outputMappedProperties: $outputMappedProperties,
-            transformationFields: static::resolveTransformationFields($properties),
-            propertyMorphablePropertyNames: $properties->filter(fn (DataProperty $property) => $property->isForMorph)
-                ->map(fn (DataProperty $property) => $property->name)
-                ->values()
-                ->all(),
+            transformationFields: static::resolveTransformationFields($properties)
         );
     }
 

--- a/src/Support/Factories/DataPropertyFactory.php
+++ b/src/Support/Factories/DataPropertyFactory.php
@@ -9,6 +9,7 @@ use Spatie\LaravelData\Attributes\AutoLazy;
 use Spatie\LaravelData\Attributes\Computed;
 use Spatie\LaravelData\Attributes\GetsCast;
 use Spatie\LaravelData\Attributes\Hidden;
+use Spatie\LaravelData\Attributes\PropertyForMorph;
 use Spatie\LaravelData\Attributes\WithCastAndTransformer;
 use Spatie\LaravelData\Attributes\WithoutValidation;
 use Spatie\LaravelData\Attributes\WithTransformer;
@@ -108,6 +109,7 @@ class DataPropertyFactory
             inputMappedName: $inputMappedName,
             outputMappedName: $outputMappedName,
             attributes: $attributes,
+            isForMorph: ! empty($reflectionProperty->getAttributes(PropertyForMorph::class)),
         );
     }
 }

--- a/src/Support/Validation/EnsurePropertyMorphable.php
+++ b/src/Support/Validation/EnsurePropertyMorphable.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Validation\ValidationRule;
 use Spatie\LaravelData\Attributes\Validation\ObjectValidationAttribute;
 use Spatie\LaravelData\Support\DataClass;
 
-class RequiresPropertyMorphableClassRule extends ObjectValidationAttribute implements ValidationRule
+class EnsurePropertyMorphable extends ObjectValidationAttribute implements ValidationRule
 {
     public function __construct(protected DataClass $dataClass)
     {

--- a/src/Support/Validation/RequiresPropertyMorphableClassRule.php
+++ b/src/Support/Validation/RequiresPropertyMorphableClassRule.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelData\Support\Validation;
 
 use Closure;
+use Exception;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Spatie\LaravelData\Attributes\Validation\ObjectValidationAttribute;
 use Spatie\LaravelData\Support\DataClass;
@@ -25,7 +26,7 @@ class RequiresPropertyMorphableClassRule extends ObjectValidationAttribute imple
 
     public static function create(string ...$parameters): static
     {
-        return new static(...$parameters);
+        throw new Exception('Cannot create a requires property morphable class rule');
     }
 
     public function validate(string $attribute, mixed $value, Closure $fail): void

--- a/src/Support/Validation/RequiresPropertyMorphableClassRule.php
+++ b/src/Support/Validation/RequiresPropertyMorphableClassRule.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Spatie\LaravelData\Support\Validation;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Spatie\LaravelData\Attributes\Validation\ObjectValidationAttribute;
+use Spatie\LaravelData\Support\DataClass;
+
+class RequiresPropertyMorphableClassRule extends ObjectValidationAttribute implements ValidationRule
+{
+    public function __construct(protected DataClass $dataClass)
+    {
+    }
+
+    public function getRule(ValidationPath $path): object|string
+    {
+        return $this;
+    }
+
+    public static function keyword(): string
+    {
+        return 'requires_property_morphable_class';
+    }
+
+    public static function create(string ...$parameters): static
+    {
+        return new static(...$parameters);
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! $this->dataClass->propertyMorphable || $this->dataClass->isAbstract) {
+            $fail('The selected :attribute is invalid for morph.');
+        }
+    }
+}

--- a/tests/CreationTest.php
+++ b/tests/CreationTest.php
@@ -1455,17 +1455,25 @@ it('can use auto lazy to construct a when loaded lazy with a manual defined rela
 });
 
 describe('property-morphable creation tests', function () {
+    enum TestPropertyMorphableEnum: string
+    {
+        case A = 'a';
+        case B = 'b';
+    };
+
     abstract class TestAbstractPropertyMorphableData extends Data implements PropertyMorphableData
     {
-        public function __construct(public string $variant)
-        {
+        public function __construct(
+            #[\Spatie\LaravelData\Attributes\PropertyForMorph]
+            public TestPropertyMorphableEnum $variant
+        ) {
         }
 
         public static function morph(array $properties): ?string
         {
             return match ($properties['variant'] ?? null) {
-                'a' => TestPropertyMorphableDataA::class,
-                'b' => TestPropertyMorphableDataB::class,
+                TestPropertyMorphableEnum::A => TestPropertyMorphableDataA::class,
+                TestPropertyMorphableEnum::B => TestPropertyMorphableDataB::class,
                 default => null,
             };
         }
@@ -1475,7 +1483,7 @@ describe('property-morphable creation tests', function () {
     {
         public function __construct(public string $a, public DummyBackedEnum $enum)
         {
-            parent::__construct('a');
+            parent::__construct(TestPropertyMorphableEnum::A);
         }
     }
 
@@ -1483,7 +1491,7 @@ describe('property-morphable creation tests', function () {
     {
         public function __construct(public string $b)
         {
-            parent::__construct('b');
+            parent::__construct(TestPropertyMorphableEnum::B);
         }
     }
 
@@ -1496,7 +1504,7 @@ describe('property-morphable creation tests', function () {
 
         expect($dataA)
             ->toBeInstanceOf(TestPropertyMorphableDataA::class)
-            ->variant->toEqual('a')
+            ->variant->toEqual(TestPropertyMorphableEnum::A)
             ->a->toEqual('foo')
             ->enum->toEqual(DummyBackedEnum::FOO);
 
@@ -1507,7 +1515,7 @@ describe('property-morphable creation tests', function () {
 
         expect($dataB)
             ->toBeInstanceOf(TestPropertyMorphableDataB::class)
-            ->variant->toEqual('b')
+            ->variant->toEqual(TestPropertyMorphableEnum::B)
             ->b->toEqual('bar');
     });
 
@@ -1519,7 +1527,7 @@ describe('property-morphable creation tests', function () {
 
         expect($dataA)
             ->toBeInstanceOf(TestPropertyMorphableDataA::class)
-            ->variant->toEqual('a')
+            ->variant->toEqual(TestPropertyMorphableEnum::A)
             ->a->toEqual('foo')
             ->enum->toEqual(DummyBackedEnum::FOO);
     });
@@ -1543,13 +1551,13 @@ describe('property-morphable creation tests', function () {
 
         expect($data->nestedCollection[0])
             ->toBeInstanceOf(TestPropertyMorphableDataA::class)
-            ->variant->toEqual('a')
+            ->variant->toEqual(TestPropertyMorphableEnum::A)
             ->a->toEqual('foo')
             ->enum->toEqual(DummyBackedEnum::FOO);
 
         expect($data->nestedCollection[1])
             ->toBeInstanceOf(TestPropertyMorphableDataB::class)
-            ->variant->toEqual('b')
+            ->variant->toEqual(TestPropertyMorphableEnum::B)
             ->b->toEqual('bar');
     });
 
@@ -1562,13 +1570,13 @@ describe('property-morphable creation tests', function () {
 
         expect($collection[0])
             ->toBeInstanceOf(TestPropertyMorphableDataA::class)
-            ->variant->toEqual('a')
+            ->variant->toEqual(TestPropertyMorphableEnum::A)
             ->a->toEqual('foo')
             ->enum->toEqual(DummyBackedEnum::FOO);
 
         expect($collection[1])
             ->toBeInstanceOf(TestPropertyMorphableDataB::class)
-            ->variant->toEqual('b')
+            ->variant->toEqual(TestPropertyMorphableEnum::B)
             ->b->toEqual('bar');
     });
 });

--- a/tests/Support/EloquentCasts/DataCollectionEloquentCastTest.php
+++ b/tests/Support/EloquentCasts/DataCollectionEloquentCastTest.php
@@ -178,8 +178,10 @@ it('can use an abstract data collection with multiple children', function () {
 it('can load and save an abstract property-morphable data collection', function () {
     abstract class TestCollectionCastAbstractPropertyMorphableData extends Data implements PropertyMorphableData
     {
-        public function __construct(public string $variant)
-        {
+        public function __construct(
+            #[\Spatie\LaravelData\Attributes\PropertyForMorph]
+            public string $variant
+        ) {
         }
 
         public static function morph(array $properties): ?string

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -2609,19 +2609,25 @@ it('it will merge validation rules', function () {
 });
 
 describe('property-morphable validation tests', function () {
+    enum TestValidationPropertyMorphableEnum: string
+    {
+        case A = 'a';
+        case B = 'b';
+    };
+
     abstract class TestValidationAbstractPropertyMorphableData extends Data implements PropertyMorphableData
     {
         public function __construct(
             #[PropertyForMorph]
-            public string $variant,
+            public TestValidationPropertyMorphableEnum $variant,
         ) {
         }
 
         public static function morph(array $properties): ?string
         {
-            return match ($properties['variant'] ?? null) {
-                'a' => TestValidationPropertyMorphableDataA::class,
-                'b' => TestValidationPropertyMorphableDataB::class,
+            return match ($properties['variant']) {
+                TestValidationPropertyMorphableEnum::A => TestValidationPropertyMorphableDataA::class,
+                TestValidationPropertyMorphableEnum::B => TestValidationPropertyMorphableDataB::class,
                 default => null,
             };
         }
@@ -2631,7 +2637,7 @@ describe('property-morphable validation tests', function () {
     {
         public function __construct(public string $a, public DummyBackedEnum $enum)
         {
-            parent::__construct('a');
+            parent::__construct(TestValidationPropertyMorphableEnum::A);
         }
     }
 
@@ -2639,7 +2645,7 @@ describe('property-morphable validation tests', function () {
     {
         public function __construct(public string $b)
         {
-            parent::__construct('b');
+            parent::__construct(TestValidationPropertyMorphableEnum::B);
         }
     }
 
@@ -2651,7 +2657,10 @@ describe('property-morphable validation tests', function () {
             ->assertErrors([
                 'variant' => 'c',
             ], [
-                'variant' => ['The selected variant is invalid for morph.'],
+                'variant' => [
+                    'The selected variant is invalid.',
+                    'The selected variant is invalid for morph.',
+                ],
             ])
             ->assertErrors([
                 'variant' => 'a',
@@ -2701,7 +2710,10 @@ describe('property-morphable validation tests', function () {
             ->assertErrors([
                 'nestedCollection' => [['variant' => 'c']],
             ], [
-                'nestedCollection.0.variant' => ['The selected nested collection.0.variant is invalid for morph.'],
+                'nestedCollection.0.variant' => [
+                    'The selected nested collection.0.variant is invalid.',
+                    'The selected nested collection.0.variant is invalid for morph.',
+                ],
             ])
             ->assertErrors([
                 'nestedCollection' => [['variant' => 'a'], ['variant' => 'b']],

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -21,6 +21,7 @@ use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Attributes\MapInputName;
 use Spatie\LaravelData\Attributes\MapName;
 use Spatie\LaravelData\Attributes\MergeValidationRules;
+use Spatie\LaravelData\Attributes\PropertyForMorph;
 use Spatie\LaravelData\Attributes\Validation\ArrayType;
 use Spatie\LaravelData\Attributes\Validation\Bail;
 use Spatie\LaravelData\Attributes\Validation\BooleanType;
@@ -2611,7 +2612,7 @@ describe('property-morphable validation tests', function () {
     abstract class TestValidationAbstractPropertyMorphableData extends Data implements PropertyMorphableData
     {
         public function __construct(
-            #[In('a', 'b')]
+            #[PropertyForMorph]
             public string $variant,
         ) {
         }
@@ -2650,7 +2651,7 @@ describe('property-morphable validation tests', function () {
             ->assertErrors([
                 'variant' => 'c',
             ], [
-                'variant' => ['The selected variant is invalid.'],
+                'variant' => ['The selected variant is invalid for morph.'],
             ])
             ->assertErrors([
                 'variant' => 'a',
@@ -2700,7 +2701,7 @@ describe('property-morphable validation tests', function () {
             ->assertErrors([
                 'nestedCollection' => [['variant' => 'c']],
             ], [
-                'nestedCollection.0.variant' => ['The selected nested collection.0.variant is invalid.'],
+                'nestedCollection.0.variant' => ['The selected nested collection.0.variant is invalid for morph.'],
             ])
             ->assertErrors([
                 'nestedCollection' => [['variant' => 'a'], ['variant' => 'b']],


### PR DESCRIPTION
This PR fixes the problems identified in https://github.com/spatie/laravel-data/pull/921#issuecomment-2618626779.

I've achieved this by doing the following:
- Requiring a `#[PropertyForMorph]` attribute to be added to property-morphable properties
  - By doing this it allows us to add validation messages if the concrete version of the data class cannot be determined
  - It also allows us to restrict the properties passed into morph and only run it if they are all available
- Casting properties when validating
  - This allows us to use more complex types e.g. enums or values with defaults for morphable properties without having to worry if the provided value has been cast already or not