### PR TITLE
Allow for nullable property-morphable children

### DIFF
--- a/src/Resolvers/DataValidationMessagesAndAttributesResolver.php
+++ b/src/Resolvers/DataValidationMessagesAndAttributesResolver.php
@@ -27,10 +27,10 @@ class DataValidationMessagesAndAttributesResolver
                 ? $fullPayload
                 : Arr::get($fullPayload, $path->get(), []);
 
-            $morphedClass = $this->dataMorphClassResolver->execute(
+            $morphedClass = $payload ? $this->dataMorphClassResolver->execute(
                 $dataClass,
                 [$payload],
-            );
+            ) : null;
 
             $dataClass = $morphedClass
                 ? $this->dataConfig->getDataClass($morphedClass)

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -2691,6 +2691,17 @@ describe('property-morphable validation tests', function () {
             ]);
     });
 
+    it('allows nullable property-morphable data', function () {
+        DataValidationAsserter::for(new class () extends Data {
+            public ?TestValidationAbstractPropertyMorphableData $morphable;
+        })
+            ->assertOk([])
+            ->assertOk(['morphable' => null])
+            ->assertErrors(['morphable' => []], [
+                'morphable.variant' => ['The morphable.variant field is required.'],
+            ]);
+    });
+
     it('can validate nested property-morphable data', function () {
         class TestValidationNestedPropertyMorphableData extends Data
         {
@@ -2700,8 +2711,6 @@ describe('property-morphable validation tests', function () {
             ) {
             }
         }
-
-        ;
 
         DataValidationAsserter::for(TestValidationNestedPropertyMorphableData::class)
             ->assertErrors([


### PR DESCRIPTION
We found another issue where this would blow up if an object had a polymorphic child that was nullable

```ts
class Vehicle {}
class Car extends Vehicle {}
class Truck extends Vehicle {}

class Garage {
  vehicle?: Vehicle
}
```